### PR TITLE
Fixed server error handling

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -151,6 +151,10 @@ Server.prototype.proxyRequest = function(req, direct){
                 }
             });
 
+            remote.on('error', function (err) {
+              req.reject(err);
+            });
+
             return remote;
         break;
 


### PR DESCRIPTION
Hello. There is a problem while connecting from server to invalid port. For example `127.0.0.1:1`

```
events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: connect ECONNREFUSED 127.0.0.1:1
    at Object.exports._errnoException (util.js:1007:11)
    at exports._exceptionWithHostPort (util.js:1030:20)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1080:14)
```

We can add an error handler to the server.js to fix this.
